### PR TITLE
Add local Kani-TTS fallback repository support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python scripts/tts_smoketest.py --text "Hello world, this is Nova speaking." --o
      ```
      The files land in `models/kani_tts`. Update `config/default_config.json` → `tts.model_dir` if you choose a different path.
      Ensure `nemo_toolkit[tts]` is installed to run the high-fidelity decoder.
+     If the Hugging Face download fails or stalls, the script automatically clones the official Kani-TTS repository into `external/kani-tts`, copies its `models/kani_tts` folder into your local `models` directory, and the runtime falls back to using that checkout.
 
 
 ## Unreal Engine Setup

--- a/TTS/kani_engine.py
+++ b/TTS/kani_engine.py
@@ -8,6 +8,7 @@ from typing import AsyncIterator, Optional
 import numpy as np
 
 from TTS.kani_tts import KaniSynthesizer
+from TTS.kani_tts.model_utils import resolve_model_directory
 
 
 logger = logging.getLogger(__name__)
@@ -40,9 +41,10 @@ class KaniTTSEngine:
 
     async def load(self) -> None:
 
-        logger.info("Loading Kani-TTS models from %s", self.config.model_dir)
+        resolved_model_dir = resolve_model_directory(self.config.model_dir, log=logger)
+        logger.info("Loading Kani-TTS models from %s", resolved_model_dir)
         self._synth = KaniSynthesizer(
-            model_path=str(self.config.model_dir),
+            model_path=str(resolved_model_dir),
             voice=self.config.voice,
             sample_rate=self.config.sample_rate,
             chunk_size=self.config.chunk_size,

--- a/TTS/kani_tts/generation/generator.py
+++ b/TTS/kani_tts/generation/generator.py
@@ -1,5 +1,6 @@
 """Text-to-speech generation logic"""
 
+import logging
 import time
 import warnings
 from threading import Thread
@@ -20,6 +21,10 @@ from ..config import (
     REPETITION_PENALTY,
     MAX_TOKENS,
 )
+from ..model_utils import resolve_model_reference
+
+
+logger = logging.getLogger(__name__)
 
 
 class TokenIDStreamer(BaseStreamer):
@@ -51,6 +56,7 @@ class TTSGenerator:
         device_map: str = "auto",
     ) -> None:
         self.model_path = model_name or MODEL_NAME
+        self.model_path = resolve_model_reference(self.model_path, log=logger)
 
         warnings.warn(
             "TODO: remove ignore_mismatched_sizes=True once the checkpoint is pinned",

--- a/TTS/kani_tts/model_utils.py
+++ b/TTS/kani_tts/model_utils.py
@@ -1,0 +1,143 @@
+"""Utilities to resolve the local Kani-TTS model directory.
+
+This module keeps the runtime code resilient when the Hugging Face
+checkpoint is unavailable.  It inspects the configured model directory,
+falls back to the vendored `external/kani-tts` checkout when necessary,
+and emits helpful log messages that describe what happened.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_MANIFEST_FILES: tuple[str, ...] = (
+    "config.json",
+    "generation_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+
+
+def _has_weight_files(directory: Path) -> bool:
+    """Return ``True`` when the folder contains any model weight files."""
+    for pattern in ("*.safetensors", "*.bin", "*.pt"):
+        if any(directory.glob(pattern)):
+            return True
+    return False
+
+
+def describe_directory_status(directory: Path) -> str:
+    """Return a human readable description of why ``directory`` is incomplete."""
+    missing: list[str] = []
+    for filename in _REQUIRED_MANIFEST_FILES:
+        if not (directory / filename).exists():
+            missing.append(filename)
+
+    weight_state = "found" if _has_weight_files(directory) else "missing"
+    parts = []
+    if missing:
+        parts.append(f"missing files: {', '.join(sorted(missing))}")
+    parts.append(f"weights: {weight_state}")
+    return "; ".join(parts)
+
+
+def is_model_dir_complete(model_dir: Path) -> bool:
+    """Check whether the supplied directory contains a usable checkpoint."""
+    directory = model_dir.expanduser()
+    if not directory.exists() or not directory.is_dir():
+        return False
+
+    for filename in _REQUIRED_MANIFEST_FILES:
+        if not (directory / filename).exists():
+            return False
+
+    if not _has_weight_files(directory):
+        return False
+
+    return True
+
+
+def project_root() -> Path:
+    """Return the repository root directory."""
+    return Path(__file__).resolve().parents[2]
+
+
+def external_repo_dir() -> Path:
+    """Directory where the official Kani-TTS repository should live."""
+    return project_root() / "external" / "kani-tts"
+
+
+def external_model_dir() -> Path:
+    """Directory that contains the fallback model weights within the repo clone."""
+    return external_repo_dir() / "models" / "kani_tts"
+
+
+def _normalise(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except Exception:  # pragma: no cover - extremely defensive
+        return path
+
+
+def _candidate_directories(preferred: Path) -> Iterable[Path]:
+    expanded = preferred.expanduser()
+    candidates = [expanded]
+
+    if not expanded.is_absolute():
+        root = project_root()
+        candidates.append(_normalise(root / expanded))
+        candidates.append(_normalise(Path.cwd() / expanded))
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        candidate = _normalise(candidate)
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+
+
+def resolve_model_directory(preferred: Path, *, log: logging.Logger | None = None) -> Path:
+    """Resolve the best available directory for the Kani-TTS model.
+
+    The function checks ``preferred`` (along with useful absolute variants)
+    and falls back to ``external/kani-tts/models/kani_tts`` when the primary
+    location is missing or obviously incomplete.
+    """
+    logger_obj = log or logger
+
+    for candidate in _candidate_directories(preferred):
+        if is_model_dir_complete(candidate):
+            return candidate
+
+    fallback = external_model_dir()
+    if is_model_dir_complete(fallback):
+        logger_obj.warning(
+            "Primary Kani-TTS model directory '%s' missing or incomplete; "
+            "using fallback '%s'.",
+            preferred,
+            fallback,
+        )
+        return fallback
+
+    if fallback.exists():
+        logger_obj.debug(
+            "Kani-TTS fallback directory '%s' exists but is incomplete (%s).",
+            fallback,
+            describe_directory_status(fallback),
+        )
+
+    # Fall back to the first candidate even if incomplete so the caller can
+    # surface a clearer error message to the user or trigger a download.
+    return _normalise(next(_candidate_directories(preferred)))
+
+
+def resolve_model_reference(reference: str | Path, *, log: logging.Logger | None = None) -> str:
+    """Return the string that should be passed to ``from_pretrained``."""
+    logger_obj = log or logger
+    resolved = resolve_model_directory(Path(str(reference)), log=logger_obj)
+    if is_model_dir_complete(resolved):
+        return str(resolved)
+    return str(reference)

--- a/external/.gitignore
+++ b/external/.gitignore
@@ -1,0 +1,2 @@
+/kani-tts/
+!.gitignore

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,22 @@
+# External Dependencies
+
+This directory is reserved for third-party source trees that are cloned at
+runtime.  When the Hugging Face snapshot for Kani-TTS is unavailable, the
+project will clone https://github.com/nineninesix-ai/kani-tts into
+`external/kani-tts` and stream the checkpoint weights directly from that
+checkout.
+
+To manage the repository manually you can run:
+
+```bash
+git clone https://github.com/nineninesix-ai/kani-tts.git external/kani-tts
+```
+
+or add it as a git submodule if your workflow prefers tracked externals:
+
+```bash
+git submodule add https://github.com/nineninesix-ai/kani-tts.git external/kani-tts
+```
+
+The runtime automatically detects `external/kani-tts/models/kani_tts` when the
+primary `models/kani_tts` directory is missing or incomplete.

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -1,10 +1,25 @@
-"""Utility script to fetch the required models for offline use."""
+"""Utility script to fetch the required models for offline use.
+
+If the Hugging Face download stalls or fails, the script falls back to
+cloning the official Kani-TTS GitHub repository and copies its weights
+into the requested ``--output`` directory.
+"""
 from __future__ import annotations
 
 import argparse
+import shutil
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+
+OFFICIAL_KANI_REPO = "https://github.com/nineninesix-ai/kani-tts.git"
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,6 +42,91 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def try_snapshot_download(*, repo_id: str, revision: str, destination: Path) -> bool:
+    try:
+        snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            local_dir=str(destination),
+            local_dir_use_symlinks=False,
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - network failure path
+        print(f"[warn] Hugging Face download failed for {repo_id}: {exc}")
+        return False
+
+
+def _git_clone_with_progress(repo_url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        print(f"[info] Repository already present at {destination}, skipping clone.")
+        return
+
+    print(f"[info] Cloning {repo_url} into {destination} ...")
+    process = subprocess.Popen(
+        ["git", "clone", "--depth", "1", "--progress", repo_url, str(destination)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    last_update = time.time()
+    line_counter = 0
+    assert process.stdout is not None
+    try:
+        for line in process.stdout:
+            line_counter += 1
+            line = line.strip()
+            if not line:
+                continue
+            if "%" in line or "Checking out files" in line or time.time() - last_update > 5:
+                print(f"[git] {line}")
+                last_update = time.time()
+            elif line_counter % 20 == 0:
+                print(f"[git] {line}")
+    finally:
+        process.stdout.close()
+
+    return_code = process.wait()
+    if return_code != 0:
+        raise RuntimeError(f"git clone failed with exit code {return_code}")
+
+    file_count = sum(1 for path in destination.rglob("*") if path.is_file())
+    print(f"[info] Clone complete. Retrieved {file_count} files from {repo_url}.")
+
+
+def _copy_tree(source: Path, destination: Path) -> None:
+    for item in source.rglob("*"):
+        relative = item.relative_to(source)
+        target = destination / relative
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, target)
+
+
+def _clone_kani_repo_into_models(output_dir: Path) -> None:
+    repo_root = project_root() / "external" / "kani-tts"
+    _git_clone_with_progress(OFFICIAL_KANI_REPO, repo_root)
+
+    source_models = repo_root / "models" / "kani_tts"
+    if not source_models.exists():
+        raise FileNotFoundError(
+            f"Kani-TTS repository cloned to {repo_root} but models/kani_tts was not found."
+        )
+
+    destination = output_dir / "kani_tts"
+    if destination.exists():
+        print(f"[info] Syncing fallback models into existing directory {destination}.")
+    else:
+        destination.mkdir(parents=True, exist_ok=True)
+
+    _copy_tree(source_models, destination)
+    print(f"[info] Copied fallback Kani-TTS weights into {destination}.")
+
+
 def main() -> None:
     args = parse_args()
     output_dir = args.output
@@ -45,12 +145,21 @@ def main() -> None:
     )
 
     if not args.skip_tts and args.tts:
-        snapshot_download(
+        tts_destination = output_dir / "kani_tts"
+        success = try_snapshot_download(
             repo_id=args.tts,
             revision=args.tts_revision,
-            local_dir=str(output_dir / "kani_tts"),
-            local_dir_use_symlinks=False,
+            destination=tts_destination,
         )
+        if not success:
+            try:
+                _clone_kani_repo_into_models(output_dir)
+            except Exception as exc:  # pragma: no cover - network path
+                print(
+                    "[error] Failed to clone the official Kani-TTS repository as a fallback:\n"
+                    f"        {exc}"
+                )
+                sys.exit(1)
 
     print(
         f"Download complete. Point config/default_config.json -> llm.model_name_or_path to: {llm_dir}"


### PR DESCRIPTION
## Summary
- add utilities that detect missing Kani-TTS checkpoints and redirect loading to external/kani-tts when available
- enhance the model download script to clone the official Kani-TTS repository with progress logging when Hugging Face download fails
- document the fallback flow and add an external directory placeholder for the runtime clone

## Testing
- pytest tests/test_kani_stream.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d6e9e82c832f80adc1b1c9830cc0